### PR TITLE
Add ZEROSSL_API_KEY environment variable validation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-.env
-database.db
 bin/
 
 *.txt

--- a/main.go
+++ b/main.go
@@ -39,5 +39,10 @@ func main() {
 	fmt.Println()
 	fmt.Println()
 
+	if len(os.Getenv("ZEROSSL_API_KEY")) == 0 {
+		fmt.Println(color.RedString("Environment variable ZEROSSL_API_KEY not found in your OS"))
+		return
+	}
+
 	cmd.Execute()
 }


### PR DESCRIPTION
This validation is added to prevent the CLI from being used without having an APIKEY configured.
![image](https://github.com/fedejuret/zerossl-cli/assets/62821179/a483929d-8de8-4c37-be3f-3e30964458b4)

